### PR TITLE
Add build root to test environment, increase timeout to 120

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -8,6 +8,7 @@ test_runner = find_program('test-runner')
 env = environment({
     'PYTHONPATH': meson.project_build_root(),
     'HSE_TEST_RUNNER_RUNNER': 'pytest',
+    'MESON_BUILD_ROOT': meson.project_build_root(),
 })
 
 wrapper = [
@@ -45,5 +46,5 @@ test(
         extension_modules,
         init_py,
     ],
-    timeout: 60
+    timeout: 120
 )


### PR DESCRIPTION
Signed-off-by: bvasandani <bvasandani@micron.com>

## Description
Test runner kept running tests in /tmp which under some systems is mapped to tmpfs. Added python-bindings tests with environment variable MESON_BUILD_ROOT for the test-runner script to use a non-tmpfs path
