### PR TITLE
Cache the Kvdb.home and Kvs.name

### DIFF
--- a/hse2/hse.in.pyx
+++ b/hse2/hse.in.pyx
@@ -179,12 +179,14 @@ cdef class Kvdb:
         if err != 0:
             raise HseException(err)
 
+        self.__home = pathlib.Path(hse_kvdb_home_get(self._c_hse_kvdb).decode())
+
     @property
     def home(self) -> pathlib.Path:
         """
         @SUB@ hse.Kvdb.home
         """
-        return pathlib.Path(hse_kvdb_home_get(self._c_hse_kvdb).decode())
+        return self.__home
 
     def close(self) -> None:
         """
@@ -437,12 +439,14 @@ cdef class Kvs:
         if err != 0:
             raise HseException(err)
 
+        self.__name = hse_kvs_name_get(self._c_hse_kvs).decode()
+
     @property
     def name(self) -> str:
         """
         @SUB@ hse.Kvs.name
         """
-        return hse_kvs_name_get(self._c_hse_kvs).decode()
+        return self.__name
 
     def close(self) -> None:
         """


### PR DESCRIPTION
These properties can't change through the lifetimes of these objects, so
let's cache them to save a few CPU cycles on subsequent accesses.

Unfortunately for us we can't make use of the following:

- functools.lru_cache(): not supported by Cython when using property
  decorators.

- functools.cached_property(): We need to support Python >= 3.6.
  Although Ubuntu 18.04 and RHEL 8 both seem to package 3.7.

Signed-off-by: Tristan Partin <tpartin@micron.com>
