### PR TITLE
Add support for user-provided buffers for KvsCursor.read()/items()

### DIFF
--- a/docstrings.py
+++ b/docstrings.py
@@ -642,7 +642,8 @@ Convenience function to return an iterator over key-value pairs in a cursor's
 view.
 
 Args:
-    max_count: Limit for the number of results.
+    key_buf: Buffer into which keys will be copied.
+    value_buf: Buffer into which values will be copied.
 
 Returns:
     Iterator of key-value pairs.
@@ -661,6 +662,10 @@ If the cursor is at EOF, attempts to read from it will not change the
 state of the cursor.
 
 This function is thread safe across disparate cursors.
+
+Args:
+    key_buf: Buffer into which the next key will be copied.
+    value_buf: Buffer into which the next value will be copied.
 
 Returns:
     tuple: Key-value pair.

--- a/hse2/hse.in.pyi
+++ b/hse2/hse.in.pyi
@@ -345,12 +345,18 @@ class KvsCursor:
         @SUB@ hse.KvsCursor.destroy
         """
         ...
-    def items(self) -> Iterator[Tuple[bytes, Optional[bytes]]]:
+    def items(
+        self,
+        key_buf: Optional[bytearray] = ...,
+        value_buf: Optional[bytearray] = ...,
+    ) -> Iterator[Tuple[Optional[bytes], Optional[bytes]]]:
         """
         @SUB@ hse.KvsCursor.items
         """
         ...
-    def read(self) -> Tuple[Optional[bytes], Optional[bytes]]:
+    def read(
+        self, key_buf: Optional[bytearray] = ..., value_buf: Optional[bytearray] = ...
+    ) -> Tuple[Optional[bytes], Optional[bytes]]:
         """
         @SUB@ hse.KvsCursor.read
         """

--- a/hse2/hse.pxd
+++ b/hse2/hse.pxd
@@ -211,6 +211,16 @@ cdef extern from "hse/hse.h":
         const void **val,
         size_t *val_len,
         cbool *eof) nogil
+    hse_err_t hse_kvs_cursor_read_copy(
+        hse_kvs_cursor *cursor,
+        unsigned int flags,
+        void *keybuf,
+        size_t keybuf_sz,
+        size_t *key_len,
+        void *valbuf,
+        size_t valbuf_sz,
+        size_t *val_len,
+        cbool *eof) nogil
     hse_err_t hse_kvs_cursor_destroy(hse_kvs_cursor *cursor) nogil
 
 


### PR DESCRIPTION
This will transparently call hse_kvs_cursor_read_copy() under the hood based
on the values of the optional buffers.

Signed-off-by: Tristan Partin <tpartin@micron.com>
