### PR TITLE
Fix a warning on Meson master

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -15,7 +15,7 @@ project(
 
 sh = find_program('sh')
 
-ci = run_command(sh, '-c', '[ ${CI+x} ]').returncode() == 0
+ci = run_command(sh, '-c', '[ ${CI+x} ]', check: false).returncode() == 0
 
 version_components = meson.project_version().split('.')
 


### PR DESCRIPTION
Meson >= 0.60 is being annoying with a warning about installing Python
files outside of paths the Python interpreter can currently see. I am in
vehement disagreement with this choice, so Meson >= 0.60 will now
produce warnings when configuring hse-python. I have expressed my
frustration with Meson maintainers since this will kill our CI with
--fatal-meson-warnings, but I don't seem to be getting anywhere.

Signed-off-by: Tristan Partin <tpartin@micron.com>
