### PR TITLE
Rename package from hse2 to hse

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Check the output of `meson configure build` or
 ### From PyPI
 
 ```shell
-python3 -m pip install hse2
+python3 -m pip install hse
 ```
 
 In this case, you may need to properly set `CFLAGS` and `LDFLAGS` according to

--- a/setup.py
+++ b/setup.py
@@ -65,32 +65,26 @@ if USE_CYTHON:
         docstrings.insert(
             HSE_PACKAGE / "hse.in.pyx",
             HSE_PACKAGE / "hse.pyx",
-            HERE / "docstrings.toml",
         )
         docstrings.insert(
             HSE_PACKAGE / "hse.pyi.pp",
             HSE_PACKAGE / "hse.pyi",
-            HERE / "docstrings.toml",
         )
         docstrings.insert(
             HSE_PACKAGE / "limits.in.pyx",
             HSE_PACKAGE / "limits.pyx",
-            HERE / "docstrings.toml",
         )
         docstrings.insert(
             HSE_PACKAGE / "limits.in.pyi",
             HSE_PACKAGE / "limits.pyi",
-            HERE / "docstrings.toml",
         )
         docstrings.insert(
             HSE_PACKAGE / "version.in.pyx",
             HSE_PACKAGE / "version.pyx",
-            HERE / "docstrings.toml",
         )
         docstrings.insert(
             HSE_PACKAGE / "version.in.pyi",
             HSE_PACKAGE / "version.pyi",
-            HERE / "docstrings.toml",
         )
 
         return cythonize(
@@ -120,7 +114,7 @@ if USE_CYTHON:
 
 
 setup(
-    name="hse2",
+    name="hse",
     version="2.2.0",
     maintainer="Micron HSE",
     maintainer_email="hse@micron.com",


### PR DESCRIPTION
We want to switch to the hse package instead of the hse2 package. The
original intent behind hse2 was misguided on my end.

Signed-off-by: Tristan Partin <tpartin@micron.com>
