### PR TITLE
Set depth in wrap-git subprojects to 1

### DIFF
--- a/subprojects/hse.wrap
+++ b/subprojects/hse.wrap
@@ -1,6 +1,7 @@
 [wrap-git]
 url = https://github.com/hse-project/hse.git
 revision = master
+depth = 1
 
 [provide]
 dependency_names = hse-2


### PR DESCRIPTION
If someone is wanting a full checkout, that is available to them. This
just makes the common case faster.

Signed-off-by: Tristan Partin <tpartin@micron.com>
