### PR TITLE
Check Cython version

### DIFF
--- a/hse2/meson.build
+++ b/hse2/meson.build
@@ -130,7 +130,7 @@ foreach m : modules
         '@0@-c'.format(m),
         input: pyx,
         command: [
-            cython,
+            cython.cmd_array(),
             '@INPUT@',
             '--output-file',
             '@OUTPUT@',

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project(
     'hse-python',
-    ['c'], # until Meson supports Cython as a language
+    ['cython', 'c'], # until Meson supports Cython as a language
     version: files('VERSION'),
     license: 'Apache-2.0',
     default_options: [
@@ -11,7 +11,7 @@ project(
         # options :).
         'force_fallback_for=xxhash,lz4,cjson',
     ],
-    meson_version: '>=0.57',
+    meson_version: '>=0.59.0'
 )
 
 version_components = meson.project_version().split('.')
@@ -23,6 +23,7 @@ hse_python_patch_version = version_components[2]
 root_module = 'hse@0@'.format(hse_python_major_version)
 
 cc = meson.get_compiler('c')
+cython = meson.get_compiler('cython')
 
 fs = import('fs')
 pymod = import('python')
@@ -30,10 +31,14 @@ pymod = import('python')
 sh = find_program('sh')
 docstrings = find_program('docstrings.py')
 pp = find_program('pp.py')
-cython = find_program('cython')
 python = pymod.find_installation('python3')
 
 ci = run_command(sh, '-c', '[ ${CI+x} ]', check: false).returncode() == 0
+
+assert(
+    cython.version().version_compare('>=0.29.21'),
+    'Cython version must be >=0.29.21'
+)
 
 # Exported for usage in hse.
 project_build_root = meson.project_build_root()


### PR DESCRIPTION
This will prevent any compiler errors from older versions of Cython
throwing people off.

Signed-off-by: Tristan Partin <tpartin@micron.com>
