### PR TITLE
Assert after probe doesn't expect probe to see a KVMS's keys in a specific order

### DIFF
--- a/tests/test_kvs.py
+++ b/tests/test_kvs.py
@@ -87,7 +87,14 @@ class KvsTests(HseTestCase):
 
                 cnt, k, kl, v, vl = self.kvs.prefix_probe(pfx2)
                 self.assertEqual(cnt, hse.KvsPfxProbeCnt.MUL)
-                self.assertTupleEqual((k, v), (b"abc1", b"value1"))
+
+                if k == b"abc1":
+                    self.assertEqual(v, b"value1")
+                elif k == b"abc2":
+                    self.assertEqual(v, b"value2")
+                else:
+                    self.assertEqual(1, 0)
+
                 self.assertEqual(kl, 4)
                 self.assertEqual(vl, 6)
 


### PR DESCRIPTION
Signed-off-by: Gaurav Ramdasi <10132364+gsramdasi@users.noreply.github.com>

## Description
Missed a spot. Failed only on Github.

In a c0kvms, a prefix probe runs through all bonsai trees from first to last and nothing can be said about the first pfx match. Depending on the kvms width, any key with the queried prefix may be encountered first.

## Issue(s) Addressed
NFSE-5171
