### PR TITLE
Remove usage of deprecated ::set-output in CI

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -54,9 +54,9 @@ jobs:
         id: determine-tag
         run: |
           if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
-            echo "::set-output name=tag::$GITHUB_BASE_REF"
+            echo "tag=$GITHUB_BASE_REF" >> "$GITHUB_OUTPUT"
           else
-            echo "::set-output name=tag::$GITHUB_REF_NAME"
+            echo "tag=$GITHUB_REF_NAME" >> "$GITHUB_OUTPUT"
           fi
 
   normal:
@@ -89,7 +89,7 @@ jobs:
             skip="true"
           fi
 
-          echo "::set-output name=skip::$skip"
+          echo "skip=$skip" >> "GITHUB_OUTPUT"
 
       - name: Checkout hse-python
         if: ${{ steps.to-skip.outputs.skip == 'false' }}
@@ -122,7 +122,7 @@ jobs:
               fi
             fi
 
-            echo "::set-output name=$p::$branch"
+            echo "$p=$branch" >> "GITHUB_OUTPUT"
           done
 
       - name: Checkout HSE


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Signed-off-by: Tristan Partin <tpartin@micron.com>
