### PR TITLE
Add dependabot support for pip packages

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,3 +5,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
https://github.blog/changelog/2022-10-24-dependabot-updates-support-for-the-python-pep-621-standard/

Signed-off-by: Tristan Partin <tpartin@micron.com>
