### PR TITLE
Add 'all' test setup

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -23,6 +23,12 @@ add_test_setup(
 )
 
 add_test_setup(
+    'all',
+    exe_wrapper: wrapper,
+    env: env
+)
+
+add_test_setup(
     'ci',
     exe_wrapper: wrapper,
     env: env


### PR DESCRIPTION
Due to a Meson issue, test suites only really work when the same suite name exists in a subproject.

Signed-off-by: Tristan Partin <tpartin@micron.com>
